### PR TITLE
KAFKA-120: (refactor) Extract ID_FIELD and COPY to Enum

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -245,8 +245,6 @@ public class MongoSinkTopicConfig extends AbstractConfig {
   private static final Pattern FULLY_QUALIFIED_CLASS_NAME =
       Pattern.compile("(" + CLASS_NAME + "\\.)*" + CLASS_NAME);
 
-  public static final String ID_FIELD = "_id";
-
   private static final List<Consumer<MongoSinkTopicConfig>> INITIALIZERS =
       asList(
           MongoSinkTopicConfig::getNamespace,

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbDelete.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbDelete.java
@@ -18,7 +18,6 @@
 
 package com.mongodb.kafka.connect.sink.cdc.debezium.mongodb;
 
-import static com.mongodb.kafka.connect.sink.cdc.debezium.mongodb.MongoDbHandler.ID_FIELD;
 import static com.mongodb.kafka.connect.sink.cdc.debezium.mongodb.MongoDbHandler.JSON_ID_FIELD;
 import static java.lang.String.format;
 
@@ -31,6 +30,7 @@ import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.cdc.CdcOperation;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public class MongoDbDelete implements CdcOperation {
 
@@ -44,7 +44,9 @@ public class MongoDbDelete implements CdcOperation {
     try {
       return new DeleteOneModel<>(
           BsonDocument.parse(
-              format("{%s: %s}", ID_FIELD, keyDoc.getString(JSON_ID_FIELD).getValue())));
+              format(
+                  "{%s: %s}",
+                  DocumentField.ID.value(), keyDoc.getString(JSON_ID_FIELD).getValue())));
     } catch (Exception exc) {
       throw new DataException(exc);
     }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbHandler.java
@@ -37,7 +37,6 @@ import com.mongodb.kafka.connect.sink.cdc.debezium.OperationType;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
 public class MongoDbHandler extends DebeziumCdcHandler {
-  static final String ID_FIELD = "_id";
   static final String JSON_ID_FIELD = "id";
   private static final Map<OperationType, CdcOperation> DEFAULT_OPERATIONS =
       new HashMap<OperationType, CdcOperation>() {

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbInsert.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbInsert.java
@@ -18,8 +18,6 @@
 
 package com.mongodb.kafka.connect.sink.cdc.debezium.mongodb;
 
-import static com.mongodb.kafka.connect.sink.cdc.debezium.mongodb.MongoDbHandler.ID_FIELD;
-
 import org.apache.kafka.connect.errors.DataException;
 
 import org.bson.BsonDocument;
@@ -30,6 +28,7 @@ import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.cdc.CdcOperation;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public class MongoDbInsert implements CdcOperation {
 
@@ -49,7 +48,9 @@ public class MongoDbInsert implements CdcOperation {
       BsonDocument insertDoc =
           BsonDocument.parse(valueDoc.get(JSON_DOC_FIELD_PATH).asString().getValue());
       return new ReplaceOneModel<>(
-          new BsonDocument(ID_FIELD, insertDoc.get(ID_FIELD)), insertDoc, REPLACE_OPTIONS);
+          new BsonDocument(DocumentField.ID.value(), insertDoc.get(DocumentField.ID.value())),
+          insertDoc,
+          REPLACE_OPTIONS);
     } catch (Exception exc) {
       throw new DataException(exc);
     }

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUpdate.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/mongodb/MongoDbUpdate.java
@@ -18,7 +18,6 @@
 
 package com.mongodb.kafka.connect.sink.cdc.debezium.mongodb;
 
-import static com.mongodb.kafka.connect.sink.cdc.debezium.mongodb.MongoDbHandler.ID_FIELD;
 import static com.mongodb.kafka.connect.sink.cdc.debezium.mongodb.MongoDbHandler.JSON_ID_FIELD;
 import static java.lang.String.format;
 
@@ -33,6 +32,7 @@ import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.cdc.CdcOperation;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public class MongoDbUpdate implements CdcOperation {
   private static final ReplaceOptions REPLACE_OPTIONS = new ReplaceOptions().upsert(true);
@@ -59,8 +59,9 @@ public class MongoDbUpdate implements CdcOperation {
       updateDoc.remove(INTERNAL_OPLOG_FIELD_V);
 
       // patch contains full new document for replacement
-      if (updateDoc.containsKey(ID_FIELD)) {
-        BsonDocument filterDoc = new BsonDocument(ID_FIELD, updateDoc.get(ID_FIELD));
+      if (updateDoc.containsKey(DocumentField.ID.value())) {
+        BsonDocument filterDoc =
+            new BsonDocument(DocumentField.ID.value(), updateDoc.get(DocumentField.ID.value()));
         return new ReplaceOneModel<>(filterDoc, updateDoc, REPLACE_OPTIONS);
       }
 
@@ -73,7 +74,9 @@ public class MongoDbUpdate implements CdcOperation {
 
       BsonDocument filterDoc =
           BsonDocument.parse(
-              format("{%s: %s}", ID_FIELD, keyDoc.getString(JSON_ID_FIELD).getValue()));
+              format(
+                  "{%s: %s}",
+                  DocumentField.ID.value(), keyDoc.getString(JSON_ID_FIELD).getValue()));
       return new UpdateOneModel<>(filterDoc, updateDoc);
 
     } catch (DataException exc) {

--- a/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/rdbms/RdbmsHandler.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/cdc/debezium/rdbms/RdbmsHandler.java
@@ -37,9 +37,9 @@ import com.mongodb.kafka.connect.sink.cdc.CdcOperation;
 import com.mongodb.kafka.connect.sink.cdc.debezium.DebeziumCdcHandler;
 import com.mongodb.kafka.connect.sink.cdc.debezium.OperationType;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public class RdbmsHandler extends DebeziumCdcHandler {
-  private static final String ID_FIELD = "_id";
   private static final String JSON_DOC_BEFORE_FIELD = "before";
   private static final String JSON_DOC_AFTER_FIELD = "after";
   private static final Logger LOGGER = LoggerFactory.getLogger(RdbmsHandler.class);
@@ -83,7 +83,7 @@ public class RdbmsHandler extends DebeziumCdcHandler {
     if (keyDoc.keySet().isEmpty()) {
       if (opType.equals(OperationType.CREATE) || opType.equals(OperationType.READ)) {
         // create: no PK info in keyDoc -> generate ObjectId
-        return new BsonDocument(ID_FIELD, new BsonObjectId());
+        return new BsonDocument(DocumentField.ID.value(), new BsonObjectId());
       }
       // update or delete: no PK info in keyDoc -> take everything in 'before' field
       try {
@@ -104,7 +104,7 @@ public class RdbmsHandler extends DebeziumCdcHandler {
     for (String f : keyDoc.keySet()) {
       pk.put(f, keyDoc.get(f));
     }
-    return new BsonDocument(ID_FIELD, pk);
+    return new BsonDocument(DocumentField.ID.value(), pk);
   }
 
   static BsonDocument generateUpsertOrReplaceDoc(
@@ -120,8 +120,8 @@ public class RdbmsHandler extends DebeziumCdcHandler {
     }
 
     BsonDocument upsertDoc = new BsonDocument();
-    if (filterDoc.containsKey(ID_FIELD)) {
-      upsertDoc.put(ID_FIELD, filterDoc.get(ID_FIELD));
+    if (filterDoc.containsKey(DocumentField.ID.value())) {
+      upsertDoc.put(DocumentField.ID.value(), filterDoc.get(DocumentField.ID.value()));
     }
 
     BsonDocument afterDoc = valueDoc.getDocument(JSON_DOC_AFTER_FIELD);

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/DocumentIdAdder.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/DocumentIdAdder.java
@@ -19,7 +19,6 @@
 package com.mongodb.kafka.connect.sink.processor;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
 
 import org.apache.kafka.connect.sink.SinkRecord;
 
@@ -28,6 +27,7 @@ import org.bson.BsonDocument;
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 import com.mongodb.kafka.connect.sink.processor.id.strategy.IdStrategy;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public class DocumentIdAdder extends PostProcessor {
   private final IdStrategy idStrategy;
@@ -46,7 +46,7 @@ public class DocumentIdAdder extends PostProcessor {
         .ifPresent(
             vd -> {
               if (shouldAppend(vd)) {
-                vd.append(ID_FIELD, idStrategy.generateId(doc, orig));
+                vd.append(DocumentField.ID.value(), idStrategy.generateId(doc, orig));
               }
             });
   }
@@ -57,6 +57,6 @@ public class DocumentIdAdder extends PostProcessor {
    *     existing _id values.
    */
   private boolean shouldAppend(final BsonDocument doc) {
-    return !doc.containsKey(ID_FIELD) || overwriteExistingIdValues;
+    return !doc.containsKey(DocumentField.ID.value()) || overwriteExistingIdValues;
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/field/projection/AllowListProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/field/projection/AllowListProjector.java
@@ -17,7 +17,6 @@
 package com.mongodb.kafka.connect.sink.processor.field.projection;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.ALLOWLIST;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -29,6 +28,7 @@ import org.bson.BsonDocument;
 import org.bson.BsonValue;
 
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public abstract class AllowListProjector extends FieldProjector {
 
@@ -58,7 +58,8 @@ public abstract class AllowListProjector extends FieldProjector {
       BsonValue value = entry.getValue();
 
       // NOTE: always keep the _id field
-      if ((!getFields().contains(key) && !key.equals(ID_FIELD)) && !checkForWildcardMatch(key)) {
+      if ((!getFields().contains(key) && !key.equals(DocumentField.ID.value()))
+          && !checkForWildcardMatch(key)) {
         iter.remove();
       }
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/field/projection/BlockListProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/field/projection/BlockListProjector.java
@@ -16,7 +16,6 @@
 package com.mongodb.kafka.connect.sink.processor.field.projection;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.BLOCKLIST;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -27,6 +26,7 @@ import org.bson.BsonDocument;
 import org.bson.BsonValue;
 
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public abstract class BlockListProjector extends FieldProjector {
 
@@ -47,7 +47,7 @@ public abstract class BlockListProjector extends FieldProjector {
       }
 
       // NOTE: never try to remove the _id field
-      if (!field.equals(ID_FIELD)) {
+      if (!field.equals(DocumentField.ID.value())) {
         doc.remove(field);
       }
       return;
@@ -87,7 +87,7 @@ public abstract class BlockListProjector extends FieldProjector {
       BsonValue value = entry.getValue();
 
       // NOTE: never try to remove the _id field
-      if (entry.getKey().equals(ID_FIELD)) {
+      if (entry.getKey().equals(DocumentField.ID.value())) {
         continue;
       }
 

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/ProvidedStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/ProvidedStrategy.java
@@ -18,8 +18,6 @@
 
 package com.mongodb.kafka.connect.sink.processor.id.strategy;
 
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
-
 import java.util.Optional;
 
 import org.apache.kafka.connect.errors.DataException;
@@ -30,6 +28,7 @@ import org.bson.BsonNull;
 import org.bson.BsonValue;
 
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 class ProvidedStrategy implements IdStrategy {
 
@@ -57,7 +56,7 @@ class ProvidedStrategy implements IdStrategy {
 
     BsonValue id =
         optionalDoc
-            .map(d -> d.get(ID_FIELD))
+            .map(d -> d.get(DocumentField.ID.value()))
             .orElseThrow(
                 () ->
                     new DataException(

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/DeleteOneDefaultStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/DeleteOneDefaultStrategy.java
@@ -18,8 +18,6 @@
 
 package com.mongodb.kafka.connect.sink.writemodel.strategy;
 
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
-
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
@@ -31,6 +29,7 @@ import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 import com.mongodb.kafka.connect.sink.processor.id.strategy.IdStrategy;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public class DeleteOneDefaultStrategy implements WriteModelStrategy {
   private IdStrategy idStrategy;
@@ -58,7 +57,8 @@ public class DeleteOneDefaultStrategy implements WriteModelStrategy {
     if (idStrategy instanceof DefaultIdFieldStrategy) {
       deleteFilter = idStrategy.generateId(document, null).asDocument();
     } else {
-      deleteFilter = new BsonDocument(ID_FIELD, idStrategy.generateId(document, null));
+      deleteFilter =
+          new BsonDocument(DocumentField.ID.value(), idStrategy.generateId(document, null));
     }
     return new DeleteOneModel<>(deleteFilter);
   }
@@ -67,7 +67,9 @@ public class DeleteOneDefaultStrategy implements WriteModelStrategy {
     @Override
     public BsonValue generateId(final SinkDocument doc, final SinkRecord orig) {
       BsonDocument kd = doc.getKeyDoc().get();
-      return kd.containsKey(ID_FIELD) ? kd : new BsonDocument(ID_FIELD, kd);
+      return kd.containsKey(DocumentField.ID.value())
+          ? kd
+          : new BsonDocument(DocumentField.ID.value(), kd);
     }
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneBusinessKeyStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneBusinessKeyStrategy.java
@@ -18,8 +18,6 @@
 
 package com.mongodb.kafka.connect.sink.writemodel.strategy;
 
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
-
 import org.apache.kafka.connect.errors.DataException;
 
 import org.bson.BSONException;
@@ -30,6 +28,7 @@ import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public class ReplaceOneBusinessKeyStrategy implements WriteModelStrategy {
 
@@ -46,8 +45,8 @@ public class ReplaceOneBusinessKeyStrategy implements WriteModelStrategy {
                         "Error: cannot build the WriteModel since the value document was missing unexpectedly"));
 
     try {
-      BsonDocument businessKey = vd.getDocument(ID_FIELD);
-      vd.remove(ID_FIELD);
+      BsonDocument businessKey = vd.getDocument(DocumentField.ID.value());
+      vd.remove(DocumentField.ID.value());
       return new ReplaceOneModel<>(businessKey, vd, REPLACE_OPTIONS);
     } catch (BSONException e) {
       throw new DataException(

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneDefaultStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/ReplaceOneDefaultStrategy.java
@@ -18,8 +18,6 @@
 
 package com.mongodb.kafka.connect.sink.writemodel.strategy;
 
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
-
 import org.apache.kafka.connect.errors.DataException;
 
 import org.bson.BsonDocument;
@@ -29,6 +27,7 @@ import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public class ReplaceOneDefaultStrategy implements WriteModelStrategy {
 
@@ -44,6 +43,9 @@ public class ReplaceOneDefaultStrategy implements WriteModelStrategy {
                     new DataException(
                         "Error: cannot build the WriteModel since the value document was missing unexpectedly"));
 
-    return new ReplaceOneModel<>(new BsonDocument(ID_FIELD, vd.get(ID_FIELD)), vd, REPLACE_OPTIONS);
+    return new ReplaceOneModel<>(
+        new BsonDocument(DocumentField.ID.value(), vd.get(DocumentField.ID.value())),
+        vd,
+        REPLACE_OPTIONS);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/UpdateOneBusinessKeyTimestampStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/UpdateOneBusinessKeyTimestampStrategy.java
@@ -16,8 +16,6 @@
 
 package com.mongodb.kafka.connect.sink.writemodel.strategy;
 
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
-
 import java.time.Instant;
 
 import org.apache.kafka.connect.errors.DataException;
@@ -31,6 +29,7 @@ import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public class UpdateOneBusinessKeyTimestampStrategy implements WriteModelStrategy {
 
@@ -51,8 +50,8 @@ public class UpdateOneBusinessKeyTimestampStrategy implements WriteModelStrategy
     BsonDateTime dateTime = new BsonDateTime(Instant.now().toEpochMilli());
 
     try {
-      BsonDocument businessKey = vd.getDocument(ID_FIELD);
-      vd.remove(ID_FIELD);
+      BsonDocument businessKey = vd.getDocument(DocumentField.ID.value());
+      vd.remove(DocumentField.ID.value());
 
       return new UpdateOneModel<>(
           businessKey,

--- a/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/UpdateOneTimestampsStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/writemodel/strategy/UpdateOneTimestampsStrategy.java
@@ -18,8 +18,6 @@
 
 package com.mongodb.kafka.connect.sink.writemodel.strategy;
 
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
-
 import java.time.Instant;
 
 import org.apache.kafka.connect.errors.DataException;
@@ -32,6 +30,7 @@ import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
+import com.mongodb.kafka.connect.util.DocumentField;
 
 public class UpdateOneTimestampsStrategy implements WriteModelStrategy {
   private static final UpdateOptions UPDATE_OPTIONS = new UpdateOptions().upsert(true);
@@ -51,7 +50,7 @@ public class UpdateOneTimestampsStrategy implements WriteModelStrategy {
     BsonDateTime dateTime = new BsonDateTime(Instant.now().toEpochMilli());
 
     return new UpdateOneModel<>(
-        new BsonDocument(ID_FIELD, vd.get(ID_FIELD)),
+        new BsonDocument(DocumentField.ID.value(), vd.get(DocumentField.ID.value())),
         new BsonDocument("$set", vd.append(FIELD_NAME_MODIFIED_TS, dateTime))
             .append("$setOnInsert", new BsonDocument(FIELD_NAME_INSERTED_TS, dateTime)),
         UPDATE_OPTIONS);

--- a/src/main/java/com/mongodb/kafka/connect/util/DocumentField.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/DocumentField.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+
+package com.mongodb.kafka.connect.util;
+
+/** Represents various common field names in BSON documents. */
+public enum DocumentField {
+  ID("_id"),
+  COPY("copy");
+
+  private final String value;
+
+  DocumentField(final String value) {
+    this.value = value;
+  }
+
+  public String value() {
+    return value;
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/util/DocumentFieldTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/util/DocumentFieldTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
+ */
+
+package com.mongodb.kafka.connect.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+class DocumentFieldTest {
+
+  @Test
+  @DisplayName("returns the enum value")
+  void testIDValue() {
+    assertEquals("_id", DocumentField.ID.value());
+  }
+
+  @Test
+  @DisplayName("returns the enum value")
+  void testCopyValue() {
+    assertEquals("copy", DocumentField.COPY.value());
+  }
+}


### PR DESCRIPTION
Since _id was getting used in both the sink and source packages, I decided to extract it out from both into a single place where it could be reused. I did introduce an Enum for it, which seems like a bit of overkill since there are only 2 at the moment, so opinions on that would be greatly welcome. Especially if this isn't an idiomatic way to do this now.