### PR TITLE
KAFKA-120: Use constants for strings used multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - [KAFKA-75](https://jira.mongodb.org/browse/KAFKA-75) Added specific configuration for the id strategies: `ProvidedInKeyStrategy` and `ProvidedInValueStrategy`.
     Added `document.id.strategy.partial.value.projection.type`, `document.id.strategy.partial.value.projection.list`,
     `document.id.strategy.partial.key.projection.type` and `document.id.strategy.partial.key.projection.list`.
+  - [KAFKA-91](https://jira.mongodb.org/browse/KAFKA-91) Improved the error messaging for the missing resume tokens in the source connector.
 
 ## 1.1.0
   - [KAFKA-45](https://jira.mongodb.org/browse/KAFKA-45) Allow the Sink connector to ignore unused source record key or value fields.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ plugins {
 }
 
 group = "org.mongodb.kafka"
-version = "1.2.0"
+version = "1.3.0-SNAPSHOT"
 description = "The official MongoDB Apache Kafka Connect Connector."
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -225,6 +225,10 @@ spotless {
     }
 }
 
+tasks.named("compileJava") {
+    dependsOn(":spotlessApply")
+}
+
 /*
  * ShadowJar
  */

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ plugins {
 }
 
 group = "org.mongodb.kafka"
-version = "1.2.0-SNAPSHOT"
+version = "1.2.0"
 description = "The official MongoDB Apache Kafka Connect Connector."
 
 java {

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -273,7 +273,24 @@ public class MongoSourceTask extends SourceTask {
           return tryCreateCursor(sourceConfig, mongoClient, resumeToken);
         }
       }
-      LOGGER.info("Failed to resume change stream: {} {}", e.getErrorMessage(), e.getErrorCode());
+      LOGGER.warn(
+          "Failed to resume change stream: {} {}\n"
+              + "=====================================================================================\n"
+              + "If the resume token is no longer available then there is the potential for data loss.\n"
+              + "Saved resume tokens are managed by Kafka and stored with the offset data.\n\n"
+              + "When running Connect in standalone mode offsets are configured using the:\n"
+              + "`offset.storage.file.filename` configuration.\n"
+              + "When running Connect in distributed mode the offsets are stored in a topic.\n\n"
+              + "Use the `kafka-consumer-groups.sh` tool with the `--reset-offsets` flag to reset\n"
+              + "offsets.\n\n"
+              + "Resetting the offset will allow for the connector to be resume from the latest resume\n"
+              + "token. Using `copy.existing=true` ensures that all data will be outputted by the\n"
+              + "connector but it will duplicate existing data.\n"
+              + "Future releases will support a configurable `errors.tolerance` level for the source\n"
+              + "connector and make use of the `postBatchResumeToken`.\n"
+              + "=====================================================================================\n",
+          e.getErrorMessage(),
+          e.getErrorCode());
       return null;
     }
   }

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -96,12 +96,12 @@ import com.mongodb.kafka.connect.Versions;
 public class MongoSourceTask extends SourceTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoSourceTask.class);
   private static final String CONNECTOR_TYPE = "source";
-  public static final String ID_FIELD = "_id";
-  public static final String COPY_KEY = "copy";
-  public static final String DB_KEY = "db";
-  public static final String COLL_KEY = "coll";
-  public static final String NS_KEY = "ns";
-  public static final String FULL_DOCUMENT = "fullDocument";
+  private static final String ID_FIELD = "_id";
+  private static final String COPY_KEY = "copy";
+  private static final String DB_KEY = "db";
+  private static final String COLL_KEY = "coll";
+  private static final String NS_KEY = "ns";
+  private static final String FULL_DOCUMENT = "fullDocument";
 
   private final Time time;
   private final AtomicBoolean isRunning = new AtomicBoolean();


### PR DESCRIPTION
Major simplification of the previous PR, basically just using a constant wherever a string is used multiple times and not using the Enum anymore.